### PR TITLE
Add c-sensitivity function, Derrida value based on c-sensitivy

### DIFF
--- a/cana/boolean_network.py
+++ b/cana/boolean_network.py
@@ -923,12 +923,14 @@ class BooleanNetwork:
 	# Plotting Methods
 	#
 	def derrida_curve(self, nsamples=10, random_seed=None, method='random'):
-		""" The Derrida Curva (also reffered as criticality measure :math:`D_s`).
-		
+		""" The Derrida Curve (also reffered as criticality measure :math:`D_s`).
+		When "mode" is set as "random" (default), it would use random sampling to estimate Derrida value
+		If "mode" is set as "sensitivity", it would use c-sensitivity to calculate Derrida value (slower)
+		You can refer to :cite:'kadelka2017influence' about why c-sensitivity can be used to caculate Derrida value
 		Args:
 			nsamples (int) : The number of samples per hammimg distance to get.
 			random_seed (int) : The random state seed.
-			methods (string) : specify the method you want. either 'randhom' or 'sensitivity'
+			method (string) : specify the method you want. either 'random' or 'sensitivity'
 		Returns:
 			(dx,dy) (tuple) : The dx and dy of the curve.
 		"""

--- a/cana/boolean_network.py
+++ b/cana/boolean_network.py
@@ -922,12 +922,13 @@ class BooleanNetwork:
 	#
 	# Plotting Methods
 	#
-	def derrida_curve(self, nsamples=10, random_seed=None):
+	def derrida_curve(self, nsamples=10, random_seed=None, method='random'):
 		""" The Derrida Curva (also reffered as criticality measure :math:`D_s`).
 		
 		Args:
 			nsamples (int) : The number of samples per hammimg distance to get.
 			random_seed (int) : The random state seed.
+			methods (string) : specify the method you want. either 'randhom' or 'sensitivity'
 		Returns:
 			(dx,dy) (tuple) : The dx and dy of the curve.
 		"""
@@ -936,17 +937,21 @@ class BooleanNetwork:
 		dx = np.linspace(0,1,self.Nnodes)
 		dy = np.zeros(self.Nnodes)
 
-		# for each possible hamming distance between the starting states
-		for hamm_dist in xrange(1, self.Nnodes + 1):
-			
-			# sample nsample times
-			for isample in xrange(nsamples):
-				rnd_config = [random.choice(['0', '1']) for b in xrange(self.Nnodes)]
-				perturbed_var = random.sample(range(self.Nnodes), hamm_dist)
-				perturbed_config = [flip_bit(rnd_config[ivar]) if ivar in perturbed_var else rnd_config[ivar] for ivar in xrange(self.Nnodes)]
-				dy[hamm_dist-1] += hamming_distance(self.step(rnd_config), self.step(perturbed_config))
-		
-		dy /= float(self.Nnodes * nsamples)
+		if method == 'random':
+			# for each possible hamming distance between the starting states
+			for hamm_dist in xrange(1, self.Nnodes + 1):
+
+				# sample nsample times
+				for isample in xrange(nsamples):
+					rnd_config = [random.choice(['0', '1']) for b in xrange(self.Nnodes)]
+					perturbed_var = random.sample(range(self.Nnodes), hamm_dist)
+					perturbed_config = [flip_bit(rnd_config[ivar]) if ivar in perturbed_var else rnd_config[ivar] for ivar in xrange(self.Nnodes)]
+					dy[hamm_dist-1] += hamming_distance(self.step(rnd_config), self.step(perturbed_config))
+
+			dy /= float(self.Nnodes * nsamples)
+		elif method == 'sensitivity':
+			for hamm_dist in xrange(1,self.Nnodes +1):
+				dy[hamm_dist-1] = sum([node.c_sensitivity(hamm_dist,mode='forceK',max_k=self.Nnodes) for node in self.nodes])/self.Nnodes
 
 		return dx, dy
 

--- a/cana/boolean_node.py
+++ b/cana/boolean_node.py
@@ -639,14 +639,21 @@ class BooleanNode(object):
 	def c_sensitivity(self, c, mode="default", max_k=0):
 		"""give the c-sensitivity of this node's Boolean function
 		c-sensitivity is defined as:
-			the mean probability that changing exactly c variables in the input variables would change output value
+			the mean probability that changing exactly c variables in input variables would change output value
 		There is another mode "forceK", which will be used to calculate Derrida value.
-			That mode would assume the number of input variables is specified as max_k
+			In that mode, it would assume the number of input variables is specified as max_k
+			this methods is equvalent to Derrida value in :cite:'kadelka2017influence', only move a normalization
+			coefficient from expression of Derrida value to c-sensitivity to simplify it
 
-		:param c:
-		:param mode: when figure as 'forceK', will assume the input variables number to be max instead of the actual number
-		:param max_k: you must specify max_k when you set mode as 'forceK'
-		:return:
+		Args:
+			c (int) : the "c" in the definition of c-senstivity above
+			mode (string) : either "default" or "forceK"
+			max_k (int) : you must specify max_k when you set mode as 'forceK'
+
+		Returns:
+		    (float)
+		See Also:
+		    :func:`~boolnets.boolean_network.derrida_curve
 		"""
 		S_c_f = 0
 		ic = min(c, self.k)

--- a/cana/drawing/canalizing_map.py
+++ b/cana/drawing/canalizing_map.py
@@ -11,6 +11,7 @@ description ...
 #	Alex Gates <ajgates@indiana.edu>
 #	All rights reserved.
 #	MIT license.
+import warnings
 try:
 	import graphviz
 except:

--- a/cana/drawing/dynamics_canalization_map.py
+++ b/cana/drawing/dynamics_canalization_map.py
@@ -11,6 +11,7 @@ description ...
 #	Alex Gates <ajgates@indiana.edu>
 #	All rights reserved.
 #	MIT license.try:
+import warnings
 try:
 	import graphviz
 except:

--- a/cana/utils.py
+++ b/cana/utils.py
@@ -69,11 +69,13 @@ def statenum_to_binstate(statenum, base):
 def statenum_to_output_list(statenum, base):
 	'''
 	Converts an interger into a list of 0 and 1, thus can feed to BooleanNode.from_output_list()
-	:param statenum: state number
-	:param base: the length of output list
-	:type statenum: int
-	:type base: int
-	:return:
+	Args:
+		statenum (int) : the state number
+		base (int) : the length of output list
+	Returns:
+		list : a list of length base, consisting of 0 and 1
+	See also:
+	    :attr:'statenum_to_binstate'
 	'''
 	return [int(i) for i in statenum_to_binstate(statenum, base)]
 
@@ -250,11 +252,12 @@ def hamming_distance(s1, s2):
 
 
 def ncr(n, r):
-	"""return the combination of r combination of n elements
+	"""return the combination number
+	the combination of selecting r items from n iterms, order doesn't matter
 
 	Args:
-	    n (int): number of elements
-	    r (int): length of combiation
+	    n (int): number of elements in collection
+	    r (int): length of combination
 	Returns:
 	    int
 	"""
@@ -263,3 +266,22 @@ def ncr(n, r):
 	numer = reduce(op.mul, xrange(n, n - r, -1))
 	denom = reduce(op.mul, xrange(1, r + 1))
 	return numer // denom
+
+
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+	'''
+	Python 2 doesn't have math.isclose()
+	Here is an equivalent function 
+	Use this to tell whether two float numbers are close enough
+		considering using == to compare floats is dangerous! 
+		2.0*3.3 != 3.0*2.2 in python!
+	Args:
+	    a (float) : the first float number
+	    b (float) : the second float number
+	    rel_tol (float) : the relative difference threshold between a and b
+	    abs_tol (float) : absolute difference threshold. not recommended for float
+
+	Returns:
+		bool
+	'''
+	return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)

--- a/cana/utils.py
+++ b/cana/utils.py
@@ -3,6 +3,7 @@ import numpy as np
 from itertools import product
 import copy
 import math
+import operator as op
 
 def recursive_map(f,d):
 	""" Normal python map, but recursive
@@ -63,6 +64,18 @@ def statenum_to_binstate(statenum, base):
 	### Consider, and test, changing this function to just
 	# bstate = bin(statenum)[2:].zfill(base)
 	return bstate
+
+
+def statenum_to_output_list(statenum, base):
+	'''
+	Converts an interger into a list of 0 and 1, thus can feed to BooleanNode.from_output_list()
+	:param statenum: state number
+	:param base: the length of output list
+	:type statenum: int
+	:type base: int
+	:return:
+	'''
+	return [int(i) for i in statenum_to_binstate(statenum, base)]
 
 def flip_bit(bit):
 	"""Flips the binary value of a state.
@@ -236,3 +249,17 @@ def hamming_distance(s1, s2):
 	return sum([s1[i] != s2[i] for i in xrange(len(s1))])
 
 
+def ncr(n, r):
+	"""return the combination of r combination of n elements
+
+	Args:
+	    n (int): number of elements
+	    r (int): length of combiation
+	Returns:
+	    int
+	"""
+	r = min(r, n - r)
+	if r == 0: return 1
+	numer = reduce(op.mul, xrange(n, n - r, -1))
+	denom = reduce(op.mul, xrange(1, r + 1))
+	return numer // denom

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -149,3 +149,11 @@
 	Year = {2016},
 	Bdsk-Url-1 = {http://www.informatics.indiana.edu/rocha/publications/NSR16.php},
 	Bdsk-Url-2 = {http://dx.doi.org/10.1038/srep24456}}
+
+@article{kadelka2017influence,
+  title={The influence of canalization on the robustness of Boolean networks},
+  author={Kadelka, Claus and Kuipers, Jack and Laubenbacher, Reinhard},
+  journal={Physica D: Nonlinear Phenomena},
+  year={2017},
+  publisher={Elsevier}
+}

--- a/tests/test_boolean_node.py
+++ b/tests/test_boolean_node.py
@@ -6,6 +6,7 @@
 from __future__ import division
 from cana.boolean_node import BooleanNode
 from cana.datasets.bools import CONTRADICTION,AND,OR,XOR,COPYx1,RULE90,RULE110
+from cana.utils import *
 
 #
 # Test Input Redundancy
@@ -485,13 +486,24 @@ def test_input_symmetry_RULE110():
 	assert (k_s ==  true_k_s) , ('Input Redundancy (input,tuples) for RULE110 node does not match. %s != %s' % (k_s,true_k_s))
 
 
+def test_sensitivity_AND():
+	n = AND()
+	s, true_s = n.c_sensitivity(1), 1 / 2
+	assert isclose(s, true_s), ('c-sensitivity(1) for AND does not match, %s != %s' % (s, true_s))
+	s, true_s = n.c_sensitivity(2), 1 / 2
+	assert isclose(s, true_s), ('c-sensitivity(2) for AND does not match, %s != %s' % (s, true_s))
+	s, true_s = n.c_sensitivity(1,'forceK',3), 1 / 3
+	assert isclose(s, true_s), ("c-sensitivity(1,'forceK',3) for AND does not match, %s != %s" % (s, true_s))
+	s, true_s = n.c_sensitivity(2, 'forceK', 3), 1 / 2
+	assert isclose(s, true_s), ("c-sensitivity(2,'forceK',3) for AND does not match, %s != %s" % (s, true_s))
 
-
-
-
-
-
-
-
-
-
+def test_sensitivity_XOR():
+	n = XOR()
+	s, true_s = n.c_sensitivity(1), 1.
+	assert isclose(s, true_s), ('c-sensitivity(1) for XOR does not match, %s != %s' % (s, true_s))
+	s, true_s = n.c_sensitivity(2), 0.
+	assert isclose(s, true_s), ('c-sensitivity(2) for XOR does not match, %s != %s' % (s, true_s))
+	s, true_s = n.c_sensitivity(1,'forceK',3), 2 / 3
+	assert isclose(s, true_s), ("c-sensitivity(1,'forceK',3) for XOR does not match, %s != %s" % (s, true_s))
+	s, true_s = n.c_sensitivity(2, 'forceK', 3), 2 / 3
+	assert isclose(s, true_s), ("c-sensitivity(2,'forceK',3) for XOR does not match, %s != %s" % (s, true_s))


### PR DESCRIPTION
I have moved some of my code from Alex' repo to here and adjust them to adapt to CANA's data structure. Hope this is useful
1, add c-sensitivity calculation for BooleanNode
2, add an option to BooleanNetwork.derrida_curve, which will use c-sensitivity to estimate the Derrida value (of course in this function they are normalized by Nnode) 
3, some functions in utils.py

citation:
Kadelka, Claus, Jack Kuipers, and Reinhard Laubenbacher. "The influence of canalization on the robustness of Boolean networks." Physica D: Nonlinear Phenomena (2017).

I have tested them. The two way of Derrida value estimation fit well. 

from cana.datasets import bio
mq=bio.DROSOPHILA()
print(mq.derrida_curve(nsamples=100)[1])
print(mq.derrida_curve(method='sensitivity')[1])

[ 0.06058824  0.11823529  0.17176471  0.22235294  0.26470588  0.31294118
  0.38117647  0.43823529  0.44705882  0.49705882  0.52764706  0.57470588
  0.61176471  0.66117647  0.67117647  0.70470588  0.73941176]
[ 0.05968858  0.11656574  0.17082612  0.222652    0.2722133   0.31966757
  0.36516003  0.40882353  0.45077855  0.49113322  0.52998332  0.56741226
  0.6034911   0.63827855  0.67182093  0.70415225  0.73529412]

feel free to change function name