### PR TITLE
Fix monotone function

### DIFF
--- a/cana/utils.py
+++ b/cana/utils.py
@@ -306,4 +306,4 @@ def input_monotone(outputs, input_idx, activation=1):
             elif activation == -1:
                 monotone_configs.append(outputs[input_confignum_0] >= outputs[input_confignum_1])
 
-        return all(c == monotone_configs[0] for c in monotone_configs)
+        return all(monotone_configs)


### PR DESCRIPTION
Original implementation will return True for both [True, True, ...] and [False, False, ...]. This is not the intended behavior since the function should tell whether it is activation or inhibition.