### PR TITLE
use correct plurals in schematodes

### DIFF
--- a/cana/canalization/boolean_canalization.py
+++ b/cana/canalization/boolean_canalization.py
@@ -226,7 +226,7 @@ def find_two_symbols_v2(k=1, prime_implicants=None, verbose=False, verbose_level
     tss = sc.schemer(prime_implicants, max_symbol=2)
     TSf = []  # collect the two-symbol schemata and calculate the one-symbol symmetries
     for c in tss:
-        representative = c.redescribed_schema[0]
+        representative = c.redescribed_schemata[0]
         bubble_indices = c.bubble_indices
         same_symbols_all = [
             [i for i, _ in enumerate(representative) if representative[i] == x]


### PR DESCRIPTION
See https://github.com/CASCI-lab/schematodes/pull/7

I mixed up "schema" and "schemata" in several places in `schematodes`, but have now fixed it. This PR fixes an issue caused by this renaming in `CANA`.